### PR TITLE
Added spacing adjustments to highlighting vertical text

### DIFF
--- a/zathura/dbus-interface.c
+++ b/zathura/dbus-interface.c
@@ -313,6 +313,11 @@ static void handle_highlight_rects(zathura_t* zathura, GVariant* parameters, GDB
       return;
     }
 
+    /* Adjust the boundaries of temp_rect, shifting the horizontal to the left by 0.2 and removing 1 character off the y.*/
+    temp_rect.x1 = temp_rect.x1 + 0.2;
+    temp_rect.x2 = temp_rect.x2 - 0.2;
+    temp_rect.y1 = temp_rect.y1 - 1;
+
     *rect = temp_rect;
     girara_list_append(rectangles[page], rect);
   }

--- a/zathura/page-widget.c
+++ b/zathura/page-widget.c
@@ -719,7 +719,7 @@ static gboolean zathura_page_widget_draw(GtkWidget* widget, cairo_t* cairo) {
       const GdkRGBA color = priv->zathura->ui.colors.highlight_color;
       cairo_set_source_rgba(cairo, color.red, color.green, color.blue, color.alpha);
       zathura_rectangle_t rectangle = recalc_rectangle(priv->page, priv->highlighter.bounds);
-      cairo_rectangle(cairo, rectangle.x1, rectangle.y1, rectangle.x2 - rectangle.x1, rectangle.y2 - rectangle.y1);
+      cairo_rectangle(cairo, rectangle.x1 + 0.2, rectangle.y1 - 1, rectangle.x2 - rectangle.x1, rectangle.y2 - rectangle.y1); /*Adjusted bounds*/
       cairo_fill(cairo);
     }
   } else {

--- a/zathura/synctex.c
+++ b/zathura/synctex.c
@@ -282,6 +282,11 @@ void synctex_highlight_rects(zathura_t* zathura, unsigned int page, girara_list_
   unsigned int cell_width  = 0;
   zathura_document_get_cell_size(zathura->document, &cell_height, &cell_width);
 
+  /* Checks if the cell of text is vertical. If so, adjust the height to remove the extra character at the top.*/
+  if(cell_height > cell_width){
+      cell_height = cell_height - 1;
+  }
+  
   unsigned int doc_height = 0;
   unsigned int doc_width  = 0;
   zathura_document_get_document_size(zathura->document, &doc_height, &doc_width);


### PR DESCRIPTION
Fixes Issue https://github.com/pwmt/zathura/issues/670

This pull request addresses an issue with the vertical text selection highlight where an extra character of vertical space appears at the top of the text, causing the highlight to be slightly misaligned. The text is also slightly shifted right.

Changes Made:
Adjusted the dimensions of the rectangles that envelop vertical text to eliminate the extra vertical space at the top and the rightward bias.
Aligned the highlight more closely with the text to ensure proper visual representation when selecting vertical blocks of text.

Testing:
Verified the fix in various scenarios with vertical, non-English text to confirm that the highlight now aligns correctly without extra spacing.